### PR TITLE
Gunicorn mojo support example

### DIFF
--- a/models/h2o_dai_german_credit/app_h2o_mojo_pipeline.py
+++ b/models/h2o_dai_german_credit/app_h2o_mojo_pipeline.py
@@ -1,44 +1,44 @@
-from certifai.model.sdk import SimpleModelWrapper
-import pandas as pd
-import numpy as np
-from numpy import nan
-import datatable as dt
 """
 Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
 Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
 """
 
+from certifai.model.sdk import SimpleModelWrapper
+import datatable as dt
 import daimojo.model
 
 model = daimojo.model("./pipeline.mojo")
 print(f"Loaded {model.uuid} from ./pipeline.mojo")
+
 
 def _get_prediction_class(preds):
     if preds[0] > preds[1]:
         return 1
     return 2
 
+
 columns = ['checkingstatus',
-    'duration',
-    'history',
-    'purpose',
-    'amount',
-    'savings',
-    'employ',
-    'installment',
-    'status',
-    'others',
-    'residence',
-    'property',
-    'age',
-    'otherplans',
-    'housing',
-    'cards',
-    'job',
-    'liable',
-    'telephone',
-    'foreign'
-]
+           'duration',
+           'history',
+           'purpose',
+           'amount',
+           'savings',
+           'employ',
+           'installment',
+           'status',
+           'others',
+           'residence',
+           'property',
+           'age',
+           'otherplans',
+           'housing',
+           'cards',
+           'job',
+           'liable',
+           'telephone',
+           'foreign'
+           ]
+
 
 class GermanCredit(SimpleModelWrapper):
     def predict(self, npinstances):
@@ -46,6 +46,7 @@ class GermanCredit(SimpleModelWrapper):
         input_dt = dt.Frame(instances, names=columns)
         predictions = model.predict(input_dt).to_pandas().apply(_get_prediction_class, axis=1)
         return predictions.values
+
 
 if __name__ == "__main__":
     # Host is set to 0.0.0.0 to allow this to be run in a docker container

--- a/models/h2o_dai_german_credit/app_h2o_mojo_pipeline_gunicorn.py
+++ b/models/h2o_dai_german_credit/app_h2o_mojo_pipeline_gunicorn.py
@@ -1,0 +1,66 @@
+"""
+Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
+Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+"""
+
+from certifai.model.sdk import SimpleModelWrapper
+
+
+class GermanCredit(SimpleModelWrapper):
+
+    @staticmethod
+    def __get_columns():
+        """
+        user-defined helper method. all user-defined methods must be prefixed by __
+        `__get_columns` is user defined helper method to list column names in order to re-create the dataframe for prediction
+        **Note**: all user defined methods must be declared inside the class as `instance methods`
+                  no user defined methods are allowed outside the scope of the class instantiating the `SimpleModelWrapper`
+                  for e.g. all methods must be declared inside the `GermanCredit` class (in this case) and referenced using `self`
+
+        :return: list of column names
+        """
+        columns = ['checkingstatus',
+                   'duration',
+                   'history',
+                   'purpose',
+                   'amount',
+                   'savings',
+                   'employ',
+                   'installment',
+                   'status',
+                   'others',
+                   'residence',
+                   'property',
+                   'age',
+                   'otherplans',
+                   'housing',
+                   'cards',
+                   'job',
+                   'liable',
+                   'telephone',
+                   'foreign'
+                   ]
+        return columns
+
+    def set_global_imports(self):
+        """
+        overridden method to make external global imports
+        When using external imports override the method to provide necessary imports. Make sure to mark them `global` to
+        be used by certifai interpreter correctly. set once,use throughout.
+        :return: None
+        """
+        global dt
+        import datatable as dt
+
+    def predict(self, npinstances):
+        # reference model by using `self.model`
+        instances = [tuple(instance) for instance in npinstances]
+        input_dt = dt.Frame(instances, names=self.__get_columns())
+        predictions = self.model.predict(input_dt).to_pandas().apply(lambda x: 1 if x[0] > x[1] else 2, axis=1)
+        return predictions.values
+
+
+if __name__ == "__main__":
+    # Host is set to 0.0.0.0 to allow this to be run in a docker container
+    app = GermanCredit(host="0.0.0.0", model_type='h2o_mojo', model_path='./pipeline.mojo')
+    app.run(log_level="warning", production=True, num_workers=3)


### PR DESCRIPTION
- reverted the old `app_h2_mojo_pipeline.py` file 
- added the new file as  `app_h2_mojo_pipeline_gunicorn.py`
- added docstrings to indicate user defined methods must be declared inside the wrapper class instantiating `SimpleModelWrapper`
- new pr since now we'll be merging this this to pre-release