### PR TITLE
read_and_save_model typo

### DIFF
--- a/models/containerized_model/templates/prediction_service.py
+++ b/models/containerized_model/templates/prediction_service.py
@@ -35,7 +35,7 @@ def main():
     if model_path is not None:
         # Copy files from remote path to local
         default_model_path = os.path.normpath(os.path.join(CURRENT_PATH, '../model', os.path.basename(model_path)))
-        read_and_save_file(model_path, default_model_path)
+        read_and_save_model(model_path, default_model_path)
     else:
         default_model_path = os.path.normpath(os.path.join(CURRENT_PATH, '../model/model.pkl'))
     model_pickle = pickle.load(open(default_model_path, 'rb'))

--- a/models/containerized_model/templates/prediction_service.py
+++ b/models/containerized_model/templates/prediction_service.py
@@ -23,7 +23,7 @@ def fetch_model_binary(model_path: str) -> bytes:
         return f.read()
 
 
-def read_and_save_model(model_path, default_model_path):
+def read_and_save_file(model_path, default_model_path):
     # Fetch model binary
     model_binary = fetch_model_binary(model_path)
     with open(default_model_path, 'wb') as f:
@@ -35,7 +35,7 @@ def main():
     if model_path is not None:
         # Copy files from remote path to local
         default_model_path = os.path.normpath(os.path.join(CURRENT_PATH, '../model', os.path.basename(model_path)))
-        read_and_save_model(model_path, default_model_path)
+        read_and_save_file(model_path, default_model_path)
     else:
         default_model_path = os.path.normpath(os.path.join(CURRENT_PATH, '../model/model.pkl'))
     model_pickle = pickle.load(open(default_model_path, 'rb'))


### PR DESCRIPTION
read_and_save_file doesn't exist in this module, perhaps in mojo service template.

i think last night changes introduced the typo