### PR TITLE
v1 template type -m proxy

### DIFF
--- a/models/containerized_model/README.md
+++ b/models/containerized_model/README.md
@@ -211,17 +211,17 @@ directory `generated-container-proxy`:
 cp -r <certifai-toolkit-path>/packages generated-container-proxy/packages
 ```
 
-### Step 3 - Configure hosted model url 
+### Step 3 - Configure hosted model url
 Add `HOSTED_MODEL_URL`  env variable to `generated-container-proxy/environment.yml` file. This will be used in the `RUN` step.
 
 Optionally, add any additional auth/secret header token to above file. Don't forget to reference the same additional env variable in `src/prediction_service.py`
 
-## Step 4 - Update request/response transformer methods inside src/prediction_service.py
+### Step 4 - Update request/response transformer methods inside src/prediction_service.py
 
-- `transform_request_to_hosted_model_schema`: update this method to apply custom transformation to hosted model service request (/POST) 
-- `transform_response_to_certifai_predict_schema`: update this method to apply custom transformation on hosted model service response to transform to certifai predict schema
+- `transform_request_to_hosted_model_schema`: update this method to apply custom transformation to hosted model service request (/POST)
+- `transform_response_to_certifai_predict_schema`: update this method to apply custom transformation on hosted model service response to transform to Certifai predict schema
 
-**More info. available as docstring in `src/prediction_serice.py`** 
+**More info. available as docstring in `src/prediction_service.py`**
 
 ### Step 5 - Build
 Run the following command to build the prediction service docker image.

--- a/models/containerized_model/README.md
+++ b/models/containerized_model/README.md
@@ -192,7 +192,7 @@ Make a request to `http://127.0.0.1:8551/predict` with the respective parameters
 
 Generate the code template for containerization of your model:
 ```
-./generate.sh -d generated-container-proxy -i certifai-proxy-container:latest -m proxy -n containerproxy -r container-proxy
+./generate.sh -d generated-container-proxy -i certifai-proxy-container:latest -m proxy
 ```
 
 This command should create a directory called `generated-container-proxy`
@@ -216,8 +216,14 @@ Add `HOSTED_MODEL_URL`  env variable to `generated-container-proxy/environment.y
 
 Optionally, add any additional auth/secret header token to above file. Don't forget to reference the same additional env variable in `src/prediction_service.py`
 
+## Step 4 - Update request/response transformer methods inside src/prediction_service.py
 
-### Step 4 - Build
+- `transform_request_to_hosted_model_schema`: update this method to apply custom transformation to hosted model service request (/POST) 
+- `transform_response_to_certifai_predict_schema`: update this method to apply custom transformation on hosted model service response to transform to certifai predict schema
+
+**More info. available as docstring in `src/prediction_serice.py`** 
+
+### Step 5 - Build
 Run the following command to build the prediction service docker image.
 
 ```
@@ -226,7 +232,7 @@ Run the following command to build the prediction service docker image.
 
 This will create a docker image with name specified at `Step 1` with `-i` parameter (`certifai-proxy-container:latest` in this case).
 
-### Step 5 - Run
+### Step 6 - Run
 Run the following command which would run the docker image using environment variables from the environments file (`environment.yml`) that is being passed:
 
 ```
@@ -235,6 +241,5 @@ Run the following command which would run the docker image using environment var
 
 This should create a docker container and host the webservice.
 
-### Step 6 - Test
+### Step 7 - Test
 Make a request to `http://127.0.0.1:8551/predict` with the respective parameters.
-

--- a/models/containerized_model/README.md
+++ b/models/containerized_model/README.md
@@ -185,3 +185,56 @@ This should create a docker container and host the webservice.
 
 ### Step 6 - Test
 Make a request to `http://127.0.0.1:8551/predict` with the respective parameters.
+
+
+## [Proxy Template](#proxy-template)
+### Step 1 - Template generation
+
+Generate the code template for containerization of your model:
+```
+./generate.sh -d generated-container-proxy -i certifai-proxy-container:latest -m proxy -n containerproxy -r container-proxy
+```
+
+This command should create a directory called `generated-container-proxy`
+in your current directory with the generated code.
+
+For more `generate` options:
+```
+./generate.sh --help
+```
+
+### Step 2 - Copy artifacts
+Copy the `packages` folder from inside the toolkit into the generated
+directory `generated-container-proxy`:
+
+```
+cp -r <certifai-toolkit-path>/packages generated-container-proxy/packages
+```
+
+### Step 3 - Configure hosted model url 
+Add `HOSTED_MODEL_URL`  env variable to `generated-container-proxy/environment.yml` file. This will be used in the `RUN` step.
+
+Optionally, add any additional auth/secret header token to above file. Don't forget to reference the same additional env variable in `src/prediction_service.py`
+
+
+### Step 4 - Build
+Run the following command to build the prediction service docker image.
+
+```
+./generated-container-proxy/container_util.sh build
+```
+
+This will create a docker image with name specified at `Step 1` with `-i` parameter (`certifai-proxy-container:latest` in this case).
+
+### Step 5 - Run
+Run the following command which would run the docker image using environment variables from the environments file (`environment.yml`) that is being passed:
+
+```
+./generated-container-proxy/container_util.sh run
+```
+
+This should create a docker container and host the webservice.
+
+### Step 6 - Test
+Make a request to `http://127.0.0.1:8551/predict` with the respective parameters.
+

--- a/models/containerized_model/templates/Dockerfile.proxy
+++ b/models/containerized_model/templates/Dockerfile.proxy
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
+# Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+#
+FROM {{BASE_DOCKER_IMAGE}}
+
+WORKDIR /
+
+COPY packages/all/cortex-certifai-common*.zip /tmp/
+COPY packages/all/cortex-certifai-model-sdk*.zip /tmp/
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install --no-cache-dir \
+     $(find /tmp -name cortex-certifai-common-*.zip)[s3] \
+     $(find /tmp -name cortex-certifai-model*.zip)
+
+RUN pip install -r /tmp/requirements.txt
+
+COPY src /src
+
+EXPOSE 8551
+
+ENTRYPOINT ["python", "-m", "src.prediction_service"]

--- a/models/containerized_model/templates/environment_proxy.yml
+++ b/models/containerized_model/templates/environment_proxy.yml
@@ -1,6 +1,6 @@
-# do not edit. auto-filled using editable environment.yaml
-
 # fully qualified HOSTED MODEL URL e.g `http://myHostedModelhostname:port/endpointUrl`
 # for example e.g `HOSTED_MODEL_URL=http://docker.for.mac.host.internal:5111/german_credit_logit/predict`
+# `HOSTED_MODEL_AUTH_HEADER_TOKEN` is optional and used as model service auth header i.e `Authorization: Bearer {HOSTED_MODEL_AUTH_HEADER_TOKEN}`
 
 HOSTED_MODEL_URL=
+HOSTED_MODEL_AUTH_HEADER_TOKEN=

--- a/models/containerized_model/templates/environment_proxy.yml
+++ b/models/containerized_model/templates/environment_proxy.yml
@@ -1,0 +1,6 @@
+# do not edit. auto-filled using editable environment.yaml
+
+# fully qualified HOSTED MODEL URL e.g `http://myHostedModelhostname:port/endpointUrl`
+# for example e.g `HOSTED_MODEL_URL=http://docker.for.mac.host.internal:5111/german_credit_logit/predict`
+
+HOSTED_MODEL_URL=

--- a/models/containerized_model/templates/proxy_service.py
+++ b/models/containerized_model/templates/proxy_service.py
@@ -139,17 +139,24 @@ if __name__ == "__main__":
     opt_args = {
         'headers': {
             'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'Authorization': f'Bearer {os.getenv("HOSTED_MODEL_AUTH_HEADER_TOKEN")}'
+            'Accept': 'application/json'
         },
         'columns': []
     }
 
+    # optional model auth header bearer token
+    hosted_model_auth_header = f'Bearer {os.getenv("HOSTED_MODEL_AUTH_HEADER_TOKEN")}' if os.getenv(
+        'HOSTED_MODEL_AUTH_HEADER_TOKEN') else None
+    if hosted_model_auth_header:
+        opt_args['headers']['Authorization'] = hosted_model_auth_header
+
+    # hosted model url
     default_hosted_model_url = ''
     hosted_model_url = os.getenv('HOSTED_MODEL_URL') if os.getenv(
         'HOSTED_MODEL_URL') else default_hosted_model_url
     if not hosted_model_url:
         raise ValueError('either `HOSTED_MODEL_URL` env variable is not set or `default_hosted_model_url` is empty')
+
     app = Proxy(hosted_model_url=hosted_model_url,
                 host="0.0.0.0",
                 **opt_args)

--- a/models/containerized_model/templates/proxy_service.py
+++ b/models/containerized_model/templates/proxy_service.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
+Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+"""
+
+import json
+import os
+from typing import Optional
+
+import requests
+from certifai.model.sdk import SimpleModelWrapper
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+import numpy as np
+
+
+class Proxy(SimpleModelWrapper):
+    """
+    Certifai Proxy Wrapper to a hosted model webservice
+    Proxy class acts as a proxy service between any hosted model webservice and Certifai.
+
+    Subclass's Certifai `SimpleModelWrapper` to start a http webservice by default at '0.0.0.0:8551/predict' which
+    - receives prediction POST request from Certifai,
+    - transforms (`transform_request_to_hosted_model_schema`) to hosted model service endpoint schema,
+    - invokes ('predict`) the hosted model service endpoint (`hosted_model_url`) with the correct json schema,
+    - transforms (`transform_response_to_certifai_predict_schema`) received response from above to Certifai `predict` schema
+    - returns the formatted response to Certifai
+    """
+
+    def __init__(self,
+                 hosted_model_url: str,
+                 host: Optional[str] = '0.0.0.0',
+                 port: Optional[int] = 8551,
+                 endpoint_url: Optional[str] = '/predict',
+                 **optional_args):
+        """
+        :param Optional[str] host: hostname proxy class service listens on, defaults to `0.0.0.0`
+        :param Optional[int] port: port proxy class service listens on, defaults to `8551`
+        :param Optional[str] endpoint_url: endpoint url for the proxy class service. defaults to `/predict`
+        :param str hosted_model_url: hosted model webservice url to invoke using http/s /POST
+        :param Optional[dict] optional_args: python dict holding any additional configuration (key/value) that maybe be required for
+            - model webservice url invoke like service http headers (may have auth tokens), or
+            - request/response transformation like column names etc.
+        """
+        self._create_session()
+        self.hosted_model_url = hosted_model_url
+        self.optional_args = optional_args
+        SimpleModelWrapper.__init__(self,
+                                    endpoint_url=endpoint_url,
+                                    host=host,
+                                    port=int(port))
+
+    def _create_session(self) -> None:
+        """Creates requests session object to hold http/https connections
+
+        :rtype: None
+        """
+        self._session = requests.Session()
+        max_retries = Retry(
+            total=5,
+            backoff_factor=0.2,
+            status_forcelist=[500, 502, 503, 504],
+            method_whitelist=frozenset(['GET', 'POST']),
+            raise_on_status=False)
+
+        self._session.mount('http://', HTTPAdapter(max_retries=max_retries))
+        self._session.mount('https://', HTTPAdapter(max_retries=max_retries))
+
+    @staticmethod
+    def transform_request_to_hosted_model_schema(instances: np.ndarray, **kwargs) -> json:
+        """Transforms incoming Certifai request to hosted model json schema. Returns json formatted string.
+        Update this method to transform data `instances` (np. ndarrays) to hosted model service expected schema.
+        Transformed data is further used to make /POST requests inside the `predict` method
+
+        :param np.ndarray instances: numpy array of shape (n_samples, n_features) to predict on
+        :param Optional[dict] kwargs: optional python dict, can be used for transformation
+        :rtype: str
+        """
+        # sample transformation for reference (uses certifai model server request schema for illustration)
+        # {
+        #     "payload": {
+        #         "instances": [[]]
+        #     }
+        # }
+        json_instances = {
+            "payload": {
+                "instances": instances.tolist()
+            }
+        }
+        return json.dumps(json_instances)
+
+    @staticmethod
+    def transform_response_to_certifai_predict_schema(data: dict, **kwargs) -> np.ndarray:
+        """Transforms hosted model service invoke /POST response dict to np.ndarrays. Returns np.ndarray
+        Update this method to transform response dict to extract and convert model predictions to
+        return numpy array of shape (n_samples,)
+
+        :param dict data: response dict containing model predictions.
+        :param Optional[dict] kwargs: optional python dict, can used for transformation.
+        :rtype np.ndarray
+        """
+
+        # sample transformation for reference (uses certifai model server response schema for illustration)
+        # {
+        #     "payload": {
+        #         "predictions": []
+        #     }
+        # }
+        #
+        #
+        return np.array(data['payload']['predictions'])
+
+    def predict(self, npinstances) -> np.ndarray:
+        """Certifai SimpleModelWrapper.predict (overridden method). Invokes the hosted model service using http/s /POST
+
+        :param np.ndarray npinstances: numpy array of shape (n_samples, n_features) to predict on
+        :return: numpy array of model predictions of shape (n_samples,)
+        :rtype: np.ndarray
+        """
+        kwargs = {}
+        transformed_request = self.transform_request_to_hosted_model_schema(npinstances, **self.optional_args)
+        resp = self._session.post(
+            self.hosted_model_url,
+            data=transformed_request,
+            headers=self.optional_args.get('headers'),
+            **kwargs
+        )
+        resp_json = json.loads(resp.text)
+        return self.transform_response_to_certifai_predict_schema(resp_json, **self.optional_args)
+
+
+if __name__ == "__main__":
+    # add any additional headers that maybe required in `opt_args.headers`.
+    # if secret/auth token needs to be passed as environment variable take a look at
+    # `Authorization` sample example as shown in the `opt_args.headers.Authorization`
+    # make sure to add any environment variable used here to
+    # `environment.yml` file for the purpose of containerization/deployment
+
+    opt_args = {
+        'headers': {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {os.getenv("HOSTED_MODEL_AUTH_HEADER_TOKEN")}'
+        },
+        'columns': []
+    }
+
+    default_hosted_model_url = ''
+    hosted_model_url = os.getenv('HOSTED_MODEL_URL') if os.getenv(
+        'HOSTED_MODEL_URL') else default_hosted_model_url
+    if not hosted_model_url:
+        raise ValueError('either `HOSTED_MODEL_URL` env variable is not set or `default_hosted_model_url` is empty')
+    app = Proxy(hosted_model_url=hosted_model_url,
+                host="0.0.0.0",
+                **opt_args)
+    app.run(log_level='Warning')

--- a/models/containerized_model/templates/requirements_proxy.txt
+++ b/models/containerized_model/templates/requirements_proxy.txt
@@ -1,0 +1,4 @@
+# add pip requirements for any additional proxy service dependencies
+# for e.g.
+
+# FLASK==1.1


### PR DESCRIPTION
issue https://github.com/CognitiveScale/certifai/issues/3073

- went ahead with model sdk rather than plain script for consistency purposes
- has the advantage of maintainability and easy upgrades(gunicorn) by adding just one global import func
