### PR TITLE
Fix: Prediction Service Deployments fail when the namespace is number

### DIFF
--- a/scan-manager/docs/setup_artifacts/deployment/h2o_mojo_deployment.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/h2o_mojo_deployment.yml
@@ -5,7 +5,7 @@ metadata:
     app: {{RESOURCE_NAME}}
     certifai_model_use_case: {{MODEL_USE_CASE_ID}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   ports:
     - name: {{RESOURCE_NAME}}
@@ -26,7 +26,7 @@ metadata:
     app: {{RESOURCE_NAME}}
     certifai_model_use_case: {{MODEL_USE_CASE_ID}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -44,7 +44,7 @@ spec:
       labels:
         app: {{RESOURCE_NAME}}
       name: {{RESOURCE_NAME}}
-      namespace: {{NAMESPACE}}
+      namespace: '{{NAMESPACE}}'
     spec:
       containers:
         - image: {{IMAGE_NAME}}

--- a/scan-manager/docs/setup_artifacts/deployment/hosted_model_proxy_deployment.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/hosted_model_proxy_deployment.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: {{RESOURCE_NAME}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   ports:
     - name: {{RESOURCE_NAME}}
@@ -24,7 +24,7 @@ metadata:
   labels:
     app: {{RESOURCE_NAME}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -42,7 +42,7 @@ spec:
       labels:
         app: {{RESOURCE_NAME}}
       name: {{RESOURCE_NAME}}
-      namespace: {{NAMESPACE}}
+      namespace: '{{NAMESPACE}}'
     spec:
       containers:
         - image: {{IMAGE_NAME}}

--- a/scan-manager/docs/setup_artifacts/deployment/r_model_deployment.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/r_model_deployment.yml
@@ -5,7 +5,7 @@ metadata:
     app: {{RESOURCE_NAME}}
     certifai_model_use_case: {{MODEL_USE_CASE_ID}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   ports:
     - name: {{RESOURCE_NAME}}
@@ -26,7 +26,7 @@ metadata:
     app: {{RESOURCE_NAME}}
     certifai_model_use_case: {{MODEL_USE_CASE_ID}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -44,7 +44,7 @@ spec:
       labels:
         app: {{RESOURCE_NAME}}
       name: {{RESOURCE_NAME}}
-      namespace: {{NAMESPACE}}
+      namespace: '{{NAMESPACE}}'
     spec:
       containers:
         - image: {{IMAGE_NAME}}

--- a/scan-manager/docs/setup_artifacts/deployment/scikit_0.23_deployment.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/scikit_0.23_deployment.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: {{RESOURCE_NAME}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   ports:
     - name: {{RESOURCE_NAME}}
@@ -24,7 +24,7 @@ metadata:
   labels:
     app: {{RESOURCE_NAME}}
   name: {{RESOURCE_NAME}}
-  namespace: {{NAMESPACE}}
+  namespace: '{{NAMESPACE}}'
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -42,7 +42,7 @@ spec:
       labels:
         app: {{RESOURCE_NAME}}
       name: {{RESOURCE_NAME}}
-      namespace: {{NAMESPACE}}
+      namespace: '{{NAMESPACE}}'
     spec:
       containers:
         - image: {{IMAGE_NAME}}


### PR DESCRIPTION
Covers [Prediction Service Deployments fail when the namespace is in all numbers #3616](https://github.com/CognitiveScale/certifai/issues/3616)