### PR TITLE
Add script to upload scan manager artifacts for azure blob storage

### DIFF
--- a/scan-manager/docs/setup_artifacts/deployment/config.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/config.yml
@@ -1,4 +1,3 @@
-
 scikit_0.23:
   deployment: scikit_0.23_deployment.yml
   default_base_image:

--- a/scan-manager/docs/setup_artifacts/deployment/config.yml
+++ b/scan-manager/docs/setup_artifacts/deployment/config.yml
@@ -2,31 +2,31 @@ scikit_0.23:
   deployment: scikit_0.23_deployment.yml
   default_base_image:
     name: python36_scikit
-    value: c12e/cortex-certifai-model-scikit:v3
+    value: c12e/cortex-certifai-model-scikit:v4-1.3.15-91-g57d0d29d
   available_base_images:
   - name: python36_scikit
-    value: c12e/cortex-certifai-model-scikit:v3
+    value: c12e/cortex-certifai-model-scikit:v4-1.3.15-91-g57d0d29d
 h2o_mojo:
   deployment: h2o_mojo_deployment.yml
   default_base_image:
     name: h2o_dai
-    value: c12e/cortex-certifai-model-h2o-mojo:v3
+    value: c12e/cortex-certifai-model-h2o-mojo:v4-1.3.15-91-g57d0d29d
   available_base_images:
   - name: h2o_dai
-    value: c12e/cortex-certifai-model-h2o-mojo:v3
+    value: c12e/cortex-certifai-model-h2o-mojo:v4-1.3.15-91-g57d0d29d
 r_model:
   deployment: r_model_deployment.yml
   default_base_image:
     name: r_model
-    value: c12e/cortex-certifai-model-r:v2
+    value: c12e/cortex-certifai-model-r:v4-1.3.15-91-g57d0d29d
   available_base_images:
   - name: r_model
-    value: c12e/cortex-certifai-model-r:v2
+    value: c12e/cortex-certifai-model-r:v4-1.3.15-91-g57d0d29d
 proxied_model:
   deployment: hosted_model_proxy_deployment.yml
   default_base_image:
     name: certifai-proxy
-    value: c12e/cortex-certifai-hosted-model:v1
+    value: c12e/cortex-certifai-hosted-model:v4-1.3.15-91-g57d0d29d
   available_base_images:
   - name: certifai-proxy
-    value: c12e/cortex-certifai-hosted-model:v1
+    value: c12e/cortex-certifai-hosted-model:v4-1.3.15-91-g57d0d29d

--- a/scan-manager/docs/setup_artifacts/upload_artifact.sh
+++ b/scan-manager/docs/setup_artifacts/upload_artifact.sh
@@ -2,6 +2,11 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+function usage() {
+  printf "Usage: upload_artifact.sh <endpoint> <access-key> <secret-key> <bucket-name>\n"
+  exit 1
+}
+
 END_POINT=$1
 ACCESS_KEY=$2
 SECRET_KEY=$3
@@ -9,7 +14,7 @@ BUCKET_NAME=$4
 
 if [[ -z $BUCKET_NAME  ]]; then
     echo "ERROR: Missing bucket"
-    exit 1
+    usage
 fi
 
 echo "uploading deployment files .."

--- a/scan-manager/docs/setup_artifacts/upload_artifact_azure.sh
+++ b/scan-manager/docs/setup_artifacts/upload_artifact_azure.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -x
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+function usage() {
+  printf "Usage: upload_artifact_azure.sh <container-name> <destination-path> <account-name> <sas-token>\n"
+  exit 1
+}
+
+CONTAINER_NAME=$1
+DIRECTORY_NAME=$2
+ACCOUNT_NAME=$3
+SAS_TOKEN=$4
+
+if [[ -z $CONTAINER_NAME  ]]; then
+    echo "ERROR: Missing destination container name"
+    usage
+fi
+
+if [[ -z $DIRECTORY_NAME  ]]; then
+    echo "ERROR: Missing destination directory name"
+    usage
+fi
+
+if [[ -z $ACCOUNT_NAME  ]]; then
+    echo "ERROR: Missing storage account name"
+    usage
+fi
+
+if [[ -z $DIRECTORY_NAME  ]]; then
+    echo "ERROR: Missing SAS TOKEN"
+    usage
+fi
+
+echo "Uploading deployment files .."
+
+az storage fs directory upload --recursive \
+  --file-system "${CONTAINER_NAME}" \
+  --source "${DIR}/deployment" \
+  --destination-path "${DIRECTORY_NAME}" \
+  --account-name "${ACCOUNT_NAME}" \
+  --sas-token "${SAS_TOKEN}"
+
+az storage fs directory upload --recursive \
+  --file-system "${CONTAINER_NAME}" \
+  --source "${DIR}/files" \
+  --destination-path "${DIRECTORY_NAME}" \
+  --account-name "${ACCOUNT_NAME}" \
+  --sas-token "${SAS_TOKEN}"


### PR DESCRIPTION
Changes:
* Script to upload artifacts using the azure cli (internally uses `azcopy`)
* updates the scan manager config file with base images that include the latest RC. (I manually built & push-ed these because of failures from the pipeline, but the same image/tag will be used when the pipeline runs).

Partially fixes https://github.com/CognitiveScale/certifai/issues/4603

This requires updates to the README/docs site - moved those to a separate PR.