### PR TITLE
Perform docker build (not push) in PR pipeline and other build script updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ notebooks/data_statistics/data/*
 notebooks/segmented_model_demo/augmented_data
 notebooks/practical_issues/encoded_german_credit.csv
 notebooks/practical_issues/preprocessed.csv
+artifacts/

--- a/build.sh
+++ b/build.sh
@@ -313,6 +313,12 @@ function main() {
     extractToolkit
     build_model_deployment_base_images
     ;;
+   local-docker)
+    setGlobals
+    PUSH_IMAGES=false
+    extractToolkit
+    build_model_deployment_base_images
+    ;;
    notebook)
     setGlobals
     activateConda

--- a/cortex-certifai-examples.gocd.yaml
+++ b/cortex-certifai-examples.gocd.yaml
@@ -47,6 +47,8 @@ common:
               mkdir -p artifacts
               cp -f certifai_toolkit.zip artifacts/
               c12e-ci
+              pip install jinja2 requirements-parser
+              ./build.sh local-docker
   snykScan: &snykScan
     clean_workspace: false
     jobs:


### PR DESCRIPTION
Overview of changes:
* Ignore `artifacts/` directory in `.gitignore` - useful when running build script locally
* Adds help message to the `build.sh` script with all options. I tried to structure the code in a way to avoid spammy output when running `./build.sh
* Adds `local-docker` option to `build.sh` script, this step will also be run in the PR pipeline


(I originally had this as part of #129, but separated it out to avoid more cascading changes with the other feature branches)