### PR TITLE
Pin markdown-link-check version in build.sh script to avoid bug

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -214,7 +214,7 @@ function testMarkdownLinks() {
     echo "********************"
     echo "markdown-link-check is not installed, it will be installed globally with npm"
     echo "https://github.com/tcort/markdown-link-check"
-    npm install -g markdown-link-check
+    npm install -g markdown-link-check@3.10.3
     echo "********************"
   else
     echo "markdown-link-check already installed"


### PR DESCRIPTION
the latest version of `markdown-link-check` is not picking up the config file, so false positives are being reported were reported in the [examples pipeline](https://gocd.dci-dev.dev-eks.insights.ai/go/tab/build/detail/cortex-certifai-examples-pr/1/examples/1/Notebooks). I've pinned to an older version where this still works.

Underlying bug  -> https://github.com/tcort/markdown-link-check/issues/246


After fixing: https://gocd.dci-dev.dev-eks.insights.ai/go/tab/build/detail/cortex-certifai-examples-pr/2/examples/1/Notebooks