### PR TITLE
Setup CI/CD pipeline to build Python base image for generating Prediction Services 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -eu
 function setGlobals() {
   set -x
   PUSH_IMAGES=false
-  BUILD_ARM=false
+  BUILD_ARM="${BUILD_ARM:-false}"
   SKIP_CONDA="${SKIP_CONDA:-false}"
   SKIP_TOOLKIT="${SKIP_TOOLKIT:-false}"
   RUN_REMOTE_EXAMPLES="${RUN_REMOTE_EXAMPLES:-false}"

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ function setGlobals() {
   NOTEBOOK_DIR="${SCRIPT_PATH}/notebooks"
   TUTORIALS_DIR="${SCRIPT_PATH}/tutorials"
   BUILD_REPORT_JSON="${ARTIFACTS_DIR}/buildReport.json"
+  BASE_IMAGE_BUILD_REPORT_JSON="${ARTIFACTS_DIR}/baseImageBuildReport.json"
   ENV_FILE="${ARTIFACTS_DIR}/.env"
   AWS_ENV_FILE="${ARTIFACTS_DIR}/.aws_env"
   AZURE_ENV_FILE="${ARTIFACTS_DIR}/.azure_env"
@@ -280,7 +281,7 @@ function buildPredictionServiceBuilderImages() {
   fi
 
   # Write build Report
-  echo "{\"python38\": \"${py38_image}\", \"python39\": \"${py39_image}\"}" > "${BUILD_REPORT_JSON}"
+  echo "{\"python38\": \"${py38_image}\", \"python39\": \"${py39_image}\"}" > "${BASE_IMAGE_BUILD_REPORT_JSON}"
 }
 
 function test() {

--- a/build.sh
+++ b/build.sh
@@ -271,6 +271,14 @@ function buildPredictionServiceBuilderImages() {
       --build-arg MINICONDA_URL=$MINICONDA_URL \
       -t "$py39_image" "${TEMPLATES_DIR}"
 
+  if [ "${PUSH_IMAGES}" = true ]; then
+    echo "Pushing images.."
+    docker push "$py38_image"
+    docker push "$py39_image"
+  else
+    echo "Skipping push.."
+  fi
+
   # Write build Report
   echo "{\"python38\": \"${py38_image}\", \"python39\": \"${py39_image}\"}" > "${BUILD_REPORT_JSON}"
 }

--- a/build.sh
+++ b/build.sh
@@ -130,15 +130,21 @@ function _installModelRequirements() {
   pip install -r "${TEMPLATES_DIR}/requirements.txt"
 }
 
-# We have to enforce a versioning strategy in the example model templates. Part of the trouble here is that template
-# images install the Certifai packages, so we should tag them in such a way to show that version.
-#
-# Current tagging strategy: `<version-counter>-<toolkit-version>`
-#
-#   `<version-counter>` is a running count we maintain based on the base image, Python version, & other dependencies
-#
-# Example: c12e/cortex-certifai-model-scikit:v3-1.3.11-120-g5d13c272
+
 function buildModelDeploymentImages() {
+  # Builds Docker Images for the example Containerized Model Types (Scikit, H2O, Proxy, R). These are images are used
+  # for the default Model Types in Scan Manager in Certifai Enterprise Version 1.3.16 and earlier.
+  #
+  # We have to enforce a versioning strategy in the example model templates. Part of the trouble here is that template
+  # images install the Certifai packages, so we should tag them in such a way to show that version.
+  #
+  # Current tagging strategy: `<version-counter>-<toolkit-version>`
+  #
+  #   `<version-counter>` is a running count we maintain based on the base image, Python version, & other dependencies
+  #
+  # Example: c12e/cortex-certifai-model-scikit:v3-1.3.11-120-g5d13c272
+  #
+  # The main reason for this tagging strategy is that earlier images were tagged with 'v1', v2, etc.
   local certifai_version
   certifai_version=$(getToolkitVersion)
 
@@ -165,6 +171,8 @@ function buildModelDeploymentImages() {
 
 
 function _buildTemplate() {
+  # Generates a Containerized Model template and builds a docker image with the contents. Arguments are for the
+  # ./generate.sh script.
   # $1 image
   # $2 model-type
   # $3 base-image (optional)

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,6 @@ function setGlobals() {
   BASE_IMAGES_DIR="${SCRIPT_PATH}/models/containerized_model/base_images"
   NOTEBOOK_DIR="${SCRIPT_PATH}/notebooks"
   TUTORIALS_DIR="${SCRIPT_PATH}/tutorials"
-  BUILD_REPORT="${ARTIFACTS_DIR}/buildReport.txt"
   BUILD_REPORT_JSON="${ARTIFACTS_DIR}/buildReport.json"
   ENV_FILE="${ARTIFACTS_DIR}/.env"
   AWS_ENV_FILE="${ARTIFACTS_DIR}/.aws_env"
@@ -189,7 +188,6 @@ function buildModelDeploymentImages() {
   _buildTemplate "${r_image}" r_model rocker/r-apt:bionic
 
   echo "{\"scikit\": \"${scikit_image}\", \"h2o\": \"${h2o_image}\", \"proxy\": \"${proxy_image}\", \"r\": \"${r_image}\" }" > "${BUILD_REPORT_JSON}"
-  printf "%s\n%s\n%s\n%s\n" "${scikit_image}" "${h2o_image}" "${proxy_image}" "${r_image}" > "${BUILD_REPORT}"
 }
 
 

--- a/build.sh
+++ b/build.sh
@@ -126,6 +126,9 @@ function buildLocal() {
   buildModelDeploymentImages
 }
 
+function _installModelRequirements() {
+  pip install -r "${TEMPLATES_DIR}/requirements.txt"
+}
 
 # We have to enforce a versioning strategy in the example model templates. Part of the trouble here is that template
 # images install the Certifai packages, so we should tag them in such a way to show that version.
@@ -432,12 +435,14 @@ function main() {
     setGlobals
     PUSH_IMAGES=true
     extractToolkit
+    _installModelRequirements
     buildModelDeploymentImages
     ;;
    local-docker)
     setGlobals
     PUSH_IMAGES=false
     extractToolkit
+    _installModelRequirements
     buildModelDeploymentImages
     ;;
    links)

--- a/cortex-certifai-examples.gocd.yaml
+++ b/cortex-certifai-examples.gocd.yaml
@@ -45,7 +45,6 @@ pipelines:
                     set -eux
                     mkdir -p artifacts
                     cp -f certifai_toolkit.zip artifacts/
-                    pip install jinja2 requirements-parser
                     ./build.sh docker
       - scan:
           clean_workspace: false
@@ -96,7 +95,6 @@ pipelines:
                     set -x
                     cp -f certifai_toolkit.zip artifacts/
                     c12e-ci
-                    pip install jinja2 requirements-parser
                     ./build.sh local-docker
           approval: manual
   cortex-certifai-examples-pr:
@@ -150,7 +148,6 @@ pipelines:
                     set -x
                     cp -f certifai_toolkit.zip artifacts/
                     c12e-ci
-                    pip install jinja2 requirements-parser
                     ./build.sh local-docker
   cortex-certifai-examples-rc:
     group: certifai
@@ -195,5 +192,4 @@ pipelines:
                     set -x
                     cp -f certifai_toolkit.zip artifacts/
                     c12e-ci
-                    pip install jinja2 requirements-parser
                     ./build.sh local-docker

--- a/cortex-certifai-examples.gocd.yaml
+++ b/cortex-certifai-examples.gocd.yaml
@@ -24,13 +24,31 @@ pipelines:
       CERTIFAI_DEV_AWS_SECRET_KEY: "AES:xVSD9Lr/T4YtP7pUd9kilQ==:590Y/Bz4G8DrCYaVOVu2lY0IkPcDEMFjGHPILP3UBNTBWlxwoFp/VuHK5zxVi527"
       SNYK_TOKEN: "AES:PbCJwUjsSYf4Knu+NwAmhg==:2KuhQtOC4bAz6XhY573V9Ppnbjir10dz8fZBYQLAJkP8kYAkj5zu45dHx/knFCRm"
     stages:
-      - build:
+      - buildModelBaseImages:
           clean_workspace: true
           jobs:
             Build:
               artifacts:
                 - build:
-                    source: artifacts/buildReport.txt
+                    source: artifacts/baseImageBuildReport.json
+              elastic_profile_id: integrationTestAgent
+              tasks:
+                - fetch:
+                    pipeline: certifai-toolkit
+                    stage: build
+                    job: build
+                    source: certifai_toolkit.zip
+                    is_file: yes
+                - script: |
+                    set -eux
+                    mkdir -p artifacts
+                    cp -f certifai_toolkit.zip artifacts/
+                    ./build.sh docker-builder
+      - build:
+          clean_workspace: true
+          jobs:
+            Build:
+              artifacts:
                 - build:
                     source: artifacts/buildReport.json
               elastic_profile_id: integrationTestAgent
@@ -65,13 +83,19 @@ pipelines:
                     job: Build
                     source: buildReport.json
                     is_file: yes
+                - fetch:
+                    pipeline: cortex-certifai-examples-build
+                    stage: buildModelBaseImages
+                    job: Build
+                    source: baseImageBuildReport.json
+                    is_file: yes
                 - script: |
                     set -x
-
                     git clone git@github.com:CognitiveScale/gocd-pipeline-scripts.git
                     ./gocd-pipeline-scripts/common/submit-snyk-scan.sh monitor buildReport.json ${SNYK_ORG}
-
                     ./gocd-pipeline-scripts/common/submit-snyk-scan.sh test buildReport.json ${SNYK_ORG}
+                    ./gocd-pipeline-scripts/common/submit-snyk-scan.sh monitor baseImageBuildReport.json ${SNYK_ORG}
+                    ./gocd-pipeline-scripts/common/submit-snyk-scan.sh test baseImageBuildReport.json ${SNYK_ORG}
       - examples:
           clean_workspace: true
           jobs:
@@ -95,7 +119,6 @@ pipelines:
                     set -x
                     cp -f certifai_toolkit.zip artifacts/
                     c12e-ci
-                    ./build.sh local-docker
           approval: manual
   cortex-certifai-examples-pr:
     group: certifai
@@ -149,6 +172,7 @@ pipelines:
                     cp -f certifai_toolkit.zip artifacts/
                     c12e-ci
                     ./build.sh local-docker
+                    ./build.sh local-docker-builder
   cortex-certifai-examples-rc:
     group: certifai
     environment_variables:

--- a/models/containerized_model/.dockerignore
+++ b/models/containerized_model/.dockerignore
@@ -1,0 +1,19 @@
+# This .dockerignore file acts as an allow-list instead of a deny-list, to avoid examples being copied into a
+# container as well as to avoid requiring updates to this file with each new example. This is especially the case
+# because 'containerized_models/' has examples both at the same level in the and beneath it filesystem
+#
+# Ignore everything
+#* 
+#containerized_model/examples
+#
+## Allow required parts of 'containerized_models' folder
+#!containerized_model
+#!containerized_model/templates/*
+#!containerized_model/generate.sh
+#!containerized_model/*.md
+#!containerized_model/*.py
+#!packages
+
+
+base_images
+examples

--- a/models/containerized_model/.dockerignore
+++ b/models/containerized_model/.dockerignore
@@ -1,19 +1,2 @@
-# This .dockerignore file acts as an allow-list instead of a deny-list, to avoid examples being copied into a
-# container as well as to avoid requiring updates to this file with each new example. This is especially the case
-# because 'containerized_models/' has examples both at the same level in the and beneath it filesystem
-#
-# Ignore everything
-#* 
-#containerized_model/examples
-#
-## Allow required parts of 'containerized_models' folder
-#!containerized_model
-#!containerized_model/templates/*
-#!containerized_model/generate.sh
-#!containerized_model/*.md
-#!containerized_model/*.py
-#!packages
-
-
 base_images
 examples

--- a/models/containerized_model/.gitignore
+++ b/models/containerized_model/.gitignore
@@ -1,0 +1,1 @@
+packages

--- a/models/containerized_model/README.md
+++ b/models/containerized_model/README.md
@@ -16,7 +16,7 @@
 - H2O MOJO runtime and license file (for running H2O MOJO models).
 - A base docker image which has all the dependencies at the specific versions that were used when the model was trained.
 - Locally installed:
-    - To generate the template: python, PyYaml, Jinja2, and requirements (`pip install -U Jinja2 PyYAML requirements-parser`)
+    - To generate the template: python, PyYaml, Jinja2, and requirements-parser (`pip install -r requirements.txt`)
     - To build/run the image: Docker
 
 ## [Overview](#overview)

--- a/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
+++ b/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
@@ -61,11 +61,11 @@ LABEL release=1 \
   name="cortex-certifai-model-python$PY_VERSION-base" \
   vendor="CognitiveScale" \
   version=1 \
-  summary="Cortex Certifai Prediction Servie Base Image" \
-  description="Cortex Certifai Enterprise Prediction Servie Base Image" \
+  summary="Cortex Certifai Enterprise Prediction Service Base Image" \
+  description="Cortex Certifai Enterprise Prediction Service Base Image" \
   com.cognitivescale.license_terms="https://www.cognitivescale.com/legal-information/"
 
- # Create .bashrc file and folders for Python/Pip that belong to the non-root user
+ # Create .bashrc file and folders for python/pip that belong to the non-root user
 RUN touch //.bashrc && \
     chown -R 1001 //.bashrc && chmod u+rwx //.bashrc && \
     mkdir -p /venv/bin /.local /.cache/pip && \
@@ -74,8 +74,8 @@ RUN touch //.bashrc && \
 
 USER 1001
 
-# Set flag to use default logging and configuration in Certifai containers. This avoid letting the application
-# write to the filesystem.
+# Set flag to use default logging and configuration in Certifai containers. This avoids letting the application write
+# to the filesystem for logs.
 ENV CFI_RESTRICTED_FS_ACCESS="true"
 
 # Add Python to path

--- a/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
+++ b/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
@@ -68,9 +68,9 @@ LABEL release=1 \
  # Create .bashrc file and folders for python/pip that belong to the non-root user
 RUN touch //.bashrc && \
     chown -R 1001 //.bashrc && chmod u+rwx //.bashrc && \
-    mkdir -p /venv/bin /.local /.cache/pip && \
-    chown -R 1001 /venv /.local /.cache/pip && \
-    chmod -R u+rwx /venv /.local /.cache/pip
+    mkdir -p /venv/bin /.local /.cache/pip /containerized_model && \
+    chown -R 1001 /venv /.local /.cache/pip /containerized_model && \
+    chmod -R u+rwx /venv /.local /.cache/pip /containerized_model
 
 USER 1001
 

--- a/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
+++ b/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
@@ -65,12 +65,12 @@ LABEL release=1 \
   description="Cortex Certifai Enterprise Prediction Service Base Image" \
   com.cognitivescale.license_terms="https://www.cognitivescale.com/legal-information/"
 
- # Create .bashrc file and folders for python/pip that belong to the non-root user
+ # Create .bashrc file and required folders for python, pip, and code that belong to the non-root user
 RUN touch //.bashrc && \
     chown -R 1001 //.bashrc && chmod u+rwx //.bashrc && \
-    mkdir -p /venv/bin /.local /.cache/pip /containerized_model && \
-    chown -R 1001 /venv /.local /.cache/pip /containerized_model && \
-    chmod -R u+rwx /venv /.local /.cache/pip /containerized_model
+    mkdir -p /venv/bin /.local /.cache/pip /containerized_model /src /model /license && \
+    chown -R 1001 /venv /.local /.cache/pip /containerized_model /src /model /license && \
+    chmod -R u+rwx /venv /.local /.cache/pip /containerized_model /src /model /license
 
 USER 1001
 

--- a/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
+++ b/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
@@ -1,0 +1,96 @@
+# Args:
+# * TOOLKIT_PATH - Path containing Certifai Toolkit 'packages' folder
+# * PY_VERSION - Python version to install. Defaults to 3.8
+# * MINICONDA_URL - URL for installing Miniconda in the container (the binary is platform specific!)
+#                   Defaults to x86_64 linux binary - see https://docs.conda.io/en/latest/miniconda.html
+
+####################################################
+## Build
+####################################################
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS build
+
+USER root
+
+# Library updates & Install wget
+RUN microdnf update -y && \
+    microdnf install wget findutils tar -y && \
+    microdnf clean all -y
+
+# Install miniconda and create an empty Python env
+#ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
+RUN wget --quiet $MINICONDA_URL -O /tmp/miniconda.sh && \
+    /bin/bash /tmp/miniconda.sh -b -p /conda -u && \
+    rm /tmp/miniconda.sh
+
+# Add conda to path
+ENV PATH=/conda/bin:$PATH
+
+# Copy Certifai Toolkit packages and other requirements.txt
+ARG TOOLKIT_PATH=certifai_toolkit
+COPY $TOOLKIT_PATH/packages/all/cortex-certifai-common* \
+     $TOOLKIT_PATH/packages/all/cortex-certifai-model-sdk* \
+     requirements.txt /tmp
+
+# Create Python env and install conda-pack
+ARG PY_VERSION=3.8
+RUN conda create -n certifai python=$PY_VERSION -y && \
+    conda install conda-pack
+
+# Install Certifai Packages and other requirements, then use conda-pack to save the env in a standalone environment (/venv).
+RUN conda run -n certifai pip install --no-cache-dir -r /tmp/requirements.txt \
+       $(find /tmp -name cortex-certifai-common-*.zip)[s3,gcp,azure] \
+       $(find /tmp -name cortex-certifai-model*.zip) && \
+    conda-pack -n certifai --ignore-missing-files -o /tmp/env.tar && \
+    mkdir /venv && \
+    cd /venv && tar xf /tmp/env.tar && rm /tmp/env.tar && \
+    /venv/bin/conda-unpack
+
+
+####################################################
+## Runtime
+####################################################
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+
+USER root
+
+# Library Updates
+RUN microdnf update -y && \
+    microdnf clean all -y
+
+LABEL release=1 \
+  name="cortex-certifai-model-python$PY_VERSION-base" \
+  vendor="CognitiveScale" \
+  version=1 \
+  summary="Cortex Certifai Prediction Servie Base Image" \
+  description="Cortex Certifai Enterprise Prediction Servie Base Image" \
+  com.cognitivescale.license_terms="https://www.cognitivescale.com/legal-information/"
+
+ # Create .bashrc file and folders for Python/Pip that belong to the non-root user
+RUN touch //.bashrc && \
+    chown -R 1001 //.bashrc && chmod u+rwx //.bashrc && \
+    mkdir -p /venv/bin /.local /.cache/pip && \
+    chown -R 1001 /venv /.local /.cache/pip && \
+    chmod -R u+rwx /venv /.local /.cache/pip
+
+USER 1001
+
+# Set flag to use default logging and configuration in Certifai containers. This avoid letting the application
+# write to the filesystem.
+ENV CFI_RESTRICTED_FS_ACCESS="true"
+
+# Add Python to path
+ENV PATH=/venv/bin:$PATH
+
+# Activate the virtualenv in the .bashrc, so python, pip, certifai, etc. are available when running the container
+RUN echo 'source /venv/bin/activate' >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Copy the python environment from the build stage
+COPY --from=build /venv /venv
+
+# Copy Prediction Service generation script
+COPY . /containerized_model
+
+# Set working directory
+WORKDIR containerized_model

--- a/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
+++ b/models/containerized_model/base_images/Dockerfile.cortex-certifai-python-model-base
@@ -17,8 +17,7 @@ RUN microdnf update -y && \
     microdnf clean all -y
 
 # Install miniconda and create an empty Python env
-#ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN wget --quiet $MINICONDA_URL -O /tmp/miniconda.sh && \
     /bin/bash /tmp/miniconda.sh -b -p /conda -u && \
     rm /tmp/miniconda.sh

--- a/models/containerized_model/generate.sh
+++ b/models/containerized_model/generate.sh
@@ -17,7 +17,8 @@ function usage() {
     printf "\tPrediction Service (prediction_service.py) file path     [-p | --prediction-service-file]\n"
     printf "\tBase docker image to be used to build the image          [-b | --base-docker-image]\n"
     printf "\tDirectory to be created                                  [-d | --dir]\n"
-    printf "\tModel type for template e.g h2o_mojo                     [-m | --model-type]\n"
+    printf "\tModel type for template. Options include 'python',       [-m | --model-type]\n"
+    printf "\t  'h2o_mojo', 'r_model', and 'proxy'\n"
     printf "\tModel (.pkl) file path                                   [-l | --model]\n"
     printf "\tPrint help                                               [-h | --help]\n"
 }

--- a/models/containerized_model/requirements.txt
+++ b/models/containerized_model/requirements.txt
@@ -1,0 +1,3 @@
+Jinja2
+PyYAML
+requirements-parser

--- a/models/containerized_model/template.py
+++ b/models/containerized_model/template.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
+Copyright (c) 2023. Cognitive Scale Inc. All rights reserved.
 Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
 """
 import argparse
@@ -67,6 +67,12 @@ def main():
                 'exec_permission': False,
             },
             'Dockerfile': {
+                'exec_permission': False,
+                'kwargs': {
+                    'BASE_DOCKER_IMAGE': args.base_docker_image
+                }
+            },
+            'Dockerfile.ubi9': {
                 'exec_permission': False,
                 'kwargs': {
                     'BASE_DOCKER_IMAGE': args.base_docker_image

--- a/models/containerized_model/templates/h2o_mojo/Dockerfile.ubi9
+++ b/models/containerized_model/templates/h2o_mojo/Dockerfile.ubi9
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023. Cognitive Scale Inc. All rights reserved.
+# Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+#
+FROM {{BASE_DOCKER_IMAGE}}
+
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
+
+COPY src /containerized_model/src
+COPY model /containerized_model/model
+COPY license /containerized_model/license
+
+EXPOSE 8551
+
+ENTRYPOINT ["python", "src/prediction_service.py"]

--- a/models/containerized_model/templates/h2o_mojo/Dockerfile.ubi9
+++ b/models/containerized_model/templates/h2o_mojo/Dockerfile.ubi9
@@ -7,10 +7,11 @@ FROM {{BASE_DOCKER_IMAGE}}
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
-COPY src /containerized_model/src
-COPY model /containerized_model/model
-COPY license /containerized_model/license
+COPY src /src
+COPY model /model
+COPY license /license
 
-EXPOSE 8551
+# Set working directory
+WORKDIR /
 
 ENTRYPOINT ["python", "src/prediction_service.py"]

--- a/models/containerized_model/templates/python/Dockerfile.ubi9
+++ b/models/containerized_model/templates/python/Dockerfile.ubi9
@@ -7,8 +7,12 @@ FROM {{BASE_DOCKER_IMAGE}}
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
-COPY src /containerized_model/src
-COPY model /containerized_model/model
+# Copy source code and model
+COPY src /src
+COPY model /model
+
+# Set working directory
+WORKDIR /
 
 EXPOSE 8551
 

--- a/models/containerized_model/templates/python/Dockerfile.ubi9
+++ b/models/containerized_model/templates/python/Dockerfile.ubi9
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023. Cognitive Scale Inc. All rights reserved.
+# Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+#
+FROM {{BASE_DOCKER_IMAGE}}
+
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
+
+COPY src /containerized_model/src
+COPY model /containerized_model/model
+
+EXPOSE 8551
+
+ENTRYPOINT ["python", "src/prediction_service.py"]

--- a/models/containerized_model/templates/python_xgboost_dmatrix/Dockerfile.ubi9
+++ b/models/containerized_model/templates/python_xgboost_dmatrix/Dockerfile.ubi9
@@ -7,8 +7,12 @@ FROM {{BASE_DOCKER_IMAGE}}
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
-COPY src /containerized_model/src
-COPY model /containerized_model/model
+# Copy source code and model
+COPY src /src
+COPY model /model
+
+# Set working directory
+WORKDIR /
 
 EXPOSE 8551
 

--- a/models/containerized_model/templates/python_xgboost_dmatrix/Dockerfile.ubi9
+++ b/models/containerized_model/templates/python_xgboost_dmatrix/Dockerfile.ubi9
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023. Cognitive Scale Inc. All rights reserved.
+# Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/cortex-certifai-examples/blob/master/LICENSE.md
+#
+FROM {{BASE_DOCKER_IMAGE}}
+
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
+
+COPY src /containerized_model/src
+COPY model /containerized_model/model
+
+EXPOSE 8551
+
+ENTRYPOINT ["python", "src/prediction_service.py"]


### PR DESCRIPTION
Notes:
* The same Dockerfile is used to build the Python3.8 and Python3.9 images 
   - Uses `registry.access.redhat.com/ubi9/ubi-minimal:latest` as the base image. The prebuilt [UBI9 Python image](https://catalog.redhat.com/software/containers/ubi9/python-39/61a61032bfd4a5234d59629e?tag=all) only offers Python 3.9 and brings in extra bloat w/ HIGH security vulnerabilities, so I instead used to use the minimal Image with `conda` to install the package
   - The overall build is similar to how the [Certifai images are built](https://github.com/CognitiveScale/certifai/blob/develop/docs/packaging.md#docker-containers) ; it uses a multi-stage build to avoid `miniconda` being in the final image.
* **I've set a up a new stage in the [cortex-certifai-examples-build Pipeline](https://gocd.dci-dev.dev-eks.insights.ai/go/pipeline/activity/cortex-certifai-examples-build)** to build these images
   - An entirely separate pipeline seemed excessive because this pipeline is already triggered with the same materials
   - I decided to keep these image builds separate from the existing `build` stage of the pipeline, to avoid confusion between the resulting images. 
   - **For this release we are continuing to build existing example model images, but after the model packaging is fully implemented the images in the `build` stage shouldn't be needed**
* I decided to the use the existing public dockerhub repo for the Python base images (https://hub.docker.com/r/c12e/cortex-certifai-model-scikit)
   - I'm not a big fan of the 'scikit' in the name, but it will be installed because of the `cortex-certifai-common` package.
   - A new tagging convention is used to differentiate from other images in the repo

-----

For local testing, you will need to [download the toolkit from GoCD](https://gocd.dci-dev.dev-eks.insights.ai/go/pipeline/activity/certifai-toolkit) and place it in the `artifacts/` folder. Then run:

```bash
SKIP_CONDA=true ./build.sh local-docker-builder
```

The images will build the images (not push), the `artifacts/baseBuildReport.json` should contain:
```json
{
  "python38": "c12e/cortex-certifai-model-scikit:base-py38-1.3.17-19-g66a6ae33-d389e12",
  "python39": "c12e/cortex-certifai-model-scikit:base-py39-1.3.17-19-g66a6ae33-d389e12"
}
```

Issue: https://github.com/CognitiveScale/certifai/issues/4763